### PR TITLE
Validate Accept-Language header in HeaderLanguageProvider

### DIFF
--- a/lib/Providers/HeaderLanguageProvider.php
+++ b/lib/Providers/HeaderLanguageProvider.php
@@ -11,14 +11,18 @@ class HeaderLanguageProvider
      */
     public function getLanguage(): ?string
     {
-        if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-            $languages = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
-
-            if (!empty($languages[0])) {
-                return strtolower(substr($languages[0], 0, 2));
-            }
+        if (!isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) || !is_string($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+            return null;
         }
 
-        return null;
+        // The header is attacker-controlled: validate the primary entry
+        // against the language-tag shape instead of trusting raw bytes.
+        $primary = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE'])[0];
+
+        if (!preg_match('/^\s*([a-zA-Z]{2})(?:[-_][a-zA-Z0-9]{2,8})*\s*(?:;.*)?$/', $primary, $matches)) {
+            return null;
+        }
+
+        return strtolower($matches[1]);
     }
 }


### PR DESCRIPTION
The provider exploded the raw `HTTP_ACCEPT_LANGUAGE` header. The primary entry is now validated against the language-tag shape and only the two-letter primary subtag is returned; malformed input resolves to null. Package suite green. Ref phpnomad/wordpress-integration#34 (flagged by Siren's wp.org review simulation).